### PR TITLE
Fix for old samples not resetting and index out of bounds

### DIFF
--- a/slidingwindow.go
+++ b/slidingwindow.go
@@ -61,10 +61,10 @@ func (sw *SlidingWindow) shifter() {
 		select {
 		case <-ticker.C:
 			sw.Lock()
-			if sw.pos = sw.pos + 1; sw.pos > len(sw.samples) {
+			if sw.pos = sw.pos + 1; sw.pos >= len(sw.samples) {
 				sw.pos = 0
-				sw.samples[sw.pos] = 0
 			}
+			sw.samples[sw.pos] = 0
 			if sw.size < len(sw.samples) {
 				sw.size++
 			}


### PR DESCRIPTION
Seems to me like the ticker will cause the library to start writing outside the bounds of sw.samples when window duration has been reached (ie. after 60 seconds with a 60 seconds window and granularity set to 1 second).

In addition, the sample is only reset for the first sample position, not the other positions when the window continues it's journey over sw.samples. 

Do you agree? 