### PR TITLE
Fix leaking ticker

### DIFF
--- a/slidingwindow.go
+++ b/slidingwindow.go
@@ -56,6 +56,7 @@ func New(window, granularity time.Duration) (*SlidingWindow, error) {
 
 func (sw *SlidingWindow) shifter() {
 	ticker := time.NewTicker(sw.granularity)
+	defer ticker.Stop()
 
 	for {
 		select {


### PR DESCRIPTION
The ticker needs to be stopped if it is not used anymore, otherwise the associated resources will not be released (https://golang.org/pkg/time/#NewTicker)